### PR TITLE
remove duplicate dependencies from gem + fix an evergreen test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
-source "http://rubygems.org"
+source :rubygems
 
-gem "httparty", "0.6.1"
+gem "httparty", ">= 0.6.1"
 
 group :development do
-	gem "mocha", "0.9.8"
-	gem "shoulda", "2.11.3"
+  gem "mocha"
+  gem "shoulda"
+  gem "jeweler"
+  gem "rcov", :platform => :ruby_18
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,29 @@ GEM
   remote: http://rubygems.org/
   specs:
     crack (0.1.8)
+    git (1.2.5)
     httparty (0.6.1)
       crack (= 0.1.8)
+    jeweler (1.8.4)
+      bundler (~> 1.0)
+      git (>= 1.2.5)
+      rake
+      rdoc
+    json (1.7.5)
     mocha (0.9.8)
       rake
     rake (0.8.7)
+    rcov (1.0.0)
+    rdoc (3.12)
+      json (~> 1.4)
     shoulda (2.11.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  httparty (= 0.6.1)
-  mocha (= 0.9.8)
-  shoulda (= 2.11.3)
+  httparty (>= 0.6.1)
+  jeweler
+  mocha
+  rcov
+  shoulda

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ Jeweler::Tasks.new do |gem|
   gem.description = %Q{A gem to shorten URLs using different services, it has one command-line utility for each supported service and one for custom shorteners called 'shorten'.}
   gem.email = "raf.magana@gmail.com"
   gem.homepage = "http://github.com/rafmagana/mush"
-  gem.authors = ["Rafael Magaña"]
+  gem.authors = ["Rafael Magana"]
 end
 Jeweler::GemcutterTasks.new
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,19 @@
 # -*- encoding: utf-8 -*-
-require 'rubygems'
-require 'rake'
+require 'bundler/setup'
 
-begin
-  require 'jeweler'
-  Jeweler::Tasks.new do |gem|
-    gem.name = "mush"
-    gem.summary = %Q{A multiple service URL shortener gem with command-line utilities}
-    gem.description = %Q{A gem to shorten URLs using different services, it has one command-line utility for each supported service and one for custom shorteners called 'shorten'.}
-    gem.email = "raf.magana@gmail.com"
-    gem.homepage = "http://github.com/rafmagana/mush"
-    gem.authors = ["Rafael Magaña"]
-    gem.add_development_dependency "shoulda", ">= 2.11.3"
-    gem.add_development_dependency "mocha", ">= 0.9.8"
-    gem.add_runtime_dependency('httparty', [">= 0.6.1"])
-  end
-  Jeweler::GemcutterTasks.new
-rescue LoadError
-  puts "Jeweler (or a dependency) not available. Install it with: gem install jeweler"
+require 'jeweler'
+Jeweler::Tasks.new do |gem|
+  gem.name = "mush"
+  gem.summary = %Q{A multiple service URL shortener gem with command-line utilities}
+  gem.description = %Q{A gem to shorten URLs using different services, it has one command-line utility for each supported service and one for custom shorteners called 'shorten'.}
+  gem.email = "raf.magana@gmail.com"
+  gem.homepage = "http://github.com/rafmagana/mush"
+  gem.authors = ["Rafael Magaña"]
 end
+Jeweler::GemcutterTasks.new
 
 require 'rake/testtask'
-Rake::TestTask.new(:test) do |test|
+Rake::TestTask.new(:default) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/test_*.rb'
   test.verbose = true
@@ -40,14 +32,9 @@ rescue LoadError
   end
 end
 
-task :test => :check_dependencies
-
-task :default => :test
-
 require 'rake/rdoctask'
 Rake::RDocTask.new do |rdoc|
-  version = File.exist?('VERSION') ? File.read('VERSION') : ""
-
+  version = File.read('VERSION')
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title = "mush #{version}"
   rdoc.rdoc_files.include('README*')

--- a/mush.gemspec
+++ b/mush.gemspec
@@ -4,15 +4,15 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{mush}
+  s.name = "mush"
   s.version = "0.2.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Rafael Maga\303\261a"]
-  s.date = %q{2011-01-17}
-  s.description = %q{A gem to shorten URLs using different services, it has one command-line utility for each supported service and one for custom shorteners called 'shorten'.}
-  s.email = %q{raf.magana@gmail.com}
-  s.executables = ["isgd", "mush", "bitly", "shorten", "owly"]
+  s.authors = ["Rafael Maga\u{f1}a"]
+  s.date = "2012-10-18"
+  s.description = "A gem to shorten URLs using different services, it has one command-line utility for each supported service and one for custom shorteners called 'shorten'."
+  s.email = "raf.magana@gmail.com"
+  s.executables = ["bitly", "isgd", "mush", "owly", "shorten"]
   s.extra_rdoc_files = [
     "LICENSE",
     "README.md"
@@ -42,41 +42,33 @@ Gem::Specification.new do |s|
     "test/helper.rb",
     "test/test_mush.rb"
   ]
-  s.homepage = %q{http://github.com/rafmagana/mush}
+  s.homepage = "http://github.com/rafmagana/mush"
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.3.7}
-  s.summary = %q{A multiple service URL shortener gem with command-line utilities}
-  s.test_files = [
-    "test/helper.rb",
-    "test/test_mush.rb"
-  ]
+  s.rubygems_version = "1.8.24"
+  s.summary = "A multiple service URL shortener gem with command-line utilities"
 
   if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httparty>, ["= 0.6.1"])
-      s.add_development_dependency(%q<mocha>, ["= 0.9.8"])
-      s.add_development_dependency(%q<shoulda>, ["= 2.11.3"])
-      s.add_development_dependency(%q<shoulda>, [">= 2.11.3"])
-      s.add_development_dependency(%q<mocha>, [">= 0.9.8"])
       s.add_runtime_dependency(%q<httparty>, [">= 0.6.1"])
+      s.add_development_dependency(%q<mocha>, [">= 0"])
+      s.add_development_dependency(%q<shoulda>, [">= 0"])
+      s.add_development_dependency(%q<jeweler>, [">= 0"])
+      s.add_development_dependency(%q<rcov>, [">= 0"])
     else
-      s.add_dependency(%q<httparty>, ["= 0.6.1"])
-      s.add_dependency(%q<mocha>, ["= 0.9.8"])
-      s.add_dependency(%q<shoulda>, ["= 2.11.3"])
-      s.add_dependency(%q<shoulda>, [">= 2.11.3"])
-      s.add_dependency(%q<mocha>, [">= 0.9.8"])
       s.add_dependency(%q<httparty>, [">= 0.6.1"])
+      s.add_dependency(%q<mocha>, [">= 0"])
+      s.add_dependency(%q<shoulda>, [">= 0"])
+      s.add_dependency(%q<jeweler>, [">= 0"])
+      s.add_dependency(%q<rcov>, [">= 0"])
     end
   else
-    s.add_dependency(%q<httparty>, ["= 0.6.1"])
-    s.add_dependency(%q<mocha>, ["= 0.9.8"])
-    s.add_dependency(%q<shoulda>, ["= 2.11.3"])
-    s.add_dependency(%q<shoulda>, [">= 2.11.3"])
-    s.add_dependency(%q<mocha>, [">= 0.9.8"])
     s.add_dependency(%q<httparty>, [">= 0.6.1"])
+    s.add_dependency(%q<mocha>, [">= 0"])
+    s.add_dependency(%q<shoulda>, [">= 0"])
+    s.add_dependency(%q<jeweler>, [">= 0"])
+    s.add_dependency(%q<rcov>, [">= 0"])
   end
 end
 

--- a/test/test_mush.rb
+++ b/test/test_mush.rb
@@ -30,7 +30,7 @@ class TestMush < Test::Unit::TestCase
     
     should "be subclasses of Mush::Service" do
       @services.each do |service|
-        assert Mush::Service, service.superclass
+        assert service < Mush::Service, "#{service} extends Mush::Service"
       end
     end
       


### PR DESCRIPTION
atm mush depends on `httpparty = 0.6.1` because of jeweler using the gemfile for dependency information,
this commit dries this up.

https://rubygems.org/gems/mush
